### PR TITLE
Add Jellyfin VM on pve2

### DIFF
--- a/proxmox/command-center/backend.tf
+++ b/proxmox/command-center/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "local" {
+    path = "/mnt/terraform-state/state/command-center/terraform.tfstate"
+  }
+}

--- a/proxmox/fleetdm/backend.tf
+++ b/proxmox/fleetdm/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "local" {
+    path = "/mnt/terraform-state/state/fleetdm/terraform.tfstate"
+  }
+}

--- a/proxmox/jellyfin/backend.tf
+++ b/proxmox/jellyfin/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "local" {
+    path = "/mnt/terraform-state/state/jellyfin/terraform.tfstate"
+  }
+}

--- a/proxmox/jellyfin/locals.tf
+++ b/proxmox/jellyfin/locals.tf
@@ -1,0 +1,20 @@
+locals {
+  sshkeys = file("~/.ssh/id_rsa.pub")
+  vms = {
+    jellyfin = {
+      template        = "ubuntu-24-04-cloud-init-template"
+      username        = var.vm_defaults.username
+      password        = var.vm_defaults.password
+      memory          = 12288
+      cores           = 4
+      sockets         = 1
+      storage_pool    = var.vm_defaults.storage_pool
+      storage_size    = var.vm_defaults.storage_size
+      network_bridge  = var.vm_defaults.network_bridge
+      skip_ipv6       = true
+      onboot          = true
+      full_clone      = true
+      hotplug         = "network,disk,usb,memory,cpu"
+    }
+  }
+}

--- a/proxmox/jellyfin/main.tf
+++ b/proxmox/jellyfin/main.tf
@@ -1,0 +1,9 @@
+module "vms" {
+  source            = "../../modules/proxmox/vm"
+  proxmox_user      = var.pm_user
+  proxmox_password  = var.pm_password
+  proxmox_api_url   = var.pm_api_url
+  pm_node           = var.pm_node
+  vms               = local.vms
+  sshkeys           = local.sshkeys
+}

--- a/proxmox/jellyfin/outputs.tf
+++ b/proxmox/jellyfin/outputs.tf
@@ -1,0 +1,7 @@
+output "vm_ids" {
+  value = module.vms.vm_ids
+}
+
+output "vm_ips" {
+  value = module.vms.vm_ips
+}

--- a/proxmox/jellyfin/variables.tf
+++ b/proxmox/jellyfin/variables.tf
@@ -1,0 +1,36 @@
+variable "pm_user" {
+  type = string
+}
+
+variable "pm_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "pm_api_url" {
+  type = string
+}
+
+variable "pm_node" {
+  type = string
+}
+
+variable "vm_defaults" {
+  description = "Default values for VM deployment"
+  sensitive = true
+  type = object({
+    username        = string
+    password        = string
+    storage_pool    = string
+    storage_size    = string
+    network_bridge  = string
+  })
+
+  default = {
+    username        = "ubuntu"
+    password        = "changeme"
+    storage_pool    = "truenas-iscsi"
+    storage_size    = "54784M"
+    network_bridge  = "vmbr0"
+  }
+}

--- a/proxmox/kubernetes/backend.tf
+++ b/proxmox/kubernetes/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "local" {
+    path = "/mnt/terraform-state/state/kubernetes/terraform.tfstate"
+  }
+}

--- a/proxmox/nginx/backend.tf
+++ b/proxmox/nginx/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "local" {
+    path = "/mnt/terraform-state/state/nginx/terraform.tfstate"
+  }
+}


### PR DESCRIPTION
## Summary
- New Terraform config `proxmox/jellyfin/` for dedicated Jellyfin VM
- 12GB RAM, 4 cores, Ubuntu 24.04 cloud-init on pve2
- GPU PCI passthrough added manually after VM creation

## After apply
1. Set DHCP reservation for 192.168.1.170
2. Assign GPU: `qm set <vmid> -hostpci0 <pci-id>,pcie=1`
3. Run Ansible role (ansible-quasarlab PR #66)