### PR TITLE
Bump Jellyfin VM to 6 cores

### DIFF
--- a/proxmox/jellyfin/locals.tf
+++ b/proxmox/jellyfin/locals.tf
@@ -6,7 +6,7 @@ locals {
       username        = var.vm_defaults.username
       password        = var.vm_defaults.password
       memory          = 12288
-      cores           = 4
+      cores           = 6
       sockets         = 1
       storage_pool    = var.vm_defaults.storage_pool
       storage_size    = var.vm_defaults.storage_size


### PR DESCRIPTION
## Summary
- Increase Jellyfin VM cores from 4 to 6
- CPU hotplug is enabled so this applies without a VM reboot

## Why
The new ffmpeg wrapper (see ansible-quasarlab PR) falls back to CPU decode for 4K HDR transcodes. Software HEVC decode of a 4K stream needs ~2-3 cores. With 4 cores total, that leaves no headroom for Jellyfin + system overhead.

## Test plan
- [ ] `terraform plan` shows only core count change
- [ ] Apply and verify cores visible in VM (`nproc`)