### PR TITLE
Pin Jellyfin VM to static IP 192.168.1.170

### DIFF
--- a/modules/proxmox/vm/main.tf
+++ b/modules/proxmox/vm/main.tf
@@ -23,7 +23,7 @@ resource "proxmox_vm_qemu" "this" {
   cipassword      = each.value.password
   ciupgrade       = true
   sshkeys         = var.sshkeys
-  ipconfig0       = "ip=dhcp"
+  ipconfig0       = each.value.ipconfig0
   bootdisk        = "scsi0"
 
   disks {

--- a/modules/proxmox/vm/variables.tf
+++ b/modules/proxmox/vm/variables.tf
@@ -32,5 +32,6 @@ variable "vms" {
     onboot          = bool
     full_clone      = bool
     hotplug         = string
+    ipconfig0       = optional(string, "ip=dhcp")
   }))
 }

--- a/proxmox/jellyfin/locals.tf
+++ b/proxmox/jellyfin/locals.tf
@@ -15,6 +15,7 @@ locals {
       onboot          = true
       full_clone      = true
       hotplug         = "network,disk,usb,memory,cpu"
+      ipconfig0       = "ip=192.168.1.170/24,gw=192.168.1.1"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add optional `ipconfig0` parameter to VM module (defaults to `ip=dhcp` for backwards compatibility)
- Pin Jellyfin VM to `192.168.1.170/24` with gateway `192.168.1.1`
- Also includes the 6-core bump from the previous commit

## Why
During GPU crash/reboot cycles, the DHCP lease renewed with a different IP (`.174` instead of `.170`), breaking Ansible, monitoring, and the NPM reverse proxy. Static IP via cloud-init ensures the IP survives any number of reboots.

## Test plan
- [x] `terraform apply` succeeded, VM boots with `.170`
- [x] Verified via `ip addr show eth0` after reboot
- [ ] Confirm other VMs still default to DHCP (no change needed)