### PR TITLE
Add Wazuh VM at 192.168.1.171

### DIFF
--- a/proxmox/wazuh/backend.tf
+++ b/proxmox/wazuh/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "local" {
+    path = "/mnt/terraform-state/state/wazuh/terraform.tfstate"
+  }
+}

--- a/proxmox/wazuh/locals.tf
+++ b/proxmox/wazuh/locals.tf
@@ -1,0 +1,21 @@
+locals {
+  sshkeys = file("~/.ssh/id_rsa.pub")
+  vms = {
+    wazuh = {
+      template        = "ubuntu-24-04-cloud-init-template"
+      username        = var.vm_defaults.username
+      password        = var.vm_defaults.password
+      memory          = 16384
+      cores           = 4
+      sockets         = 1
+      storage_pool    = var.vm_defaults.storage_pool
+      storage_size    = var.vm_defaults.storage_size
+      network_bridge  = var.vm_defaults.network_bridge
+      skip_ipv6       = true
+      onboot          = true
+      full_clone      = true
+      hotplug         = "network,disk,usb,memory,cpu"
+      ipconfig0       = "ip=192.168.1.171/24,gw=192.168.1.1"
+    }
+  }
+}

--- a/proxmox/wazuh/main.tf
+++ b/proxmox/wazuh/main.tf
@@ -1,0 +1,9 @@
+module "vms" {
+  source            = "../../modules/proxmox/vm"
+  proxmox_user      = var.pm_user
+  proxmox_password  = var.pm_password
+  proxmox_api_url   = var.pm_api_url
+  pm_node           = var.pm_node
+  vms               = local.vms
+  sshkeys           = local.sshkeys
+}

--- a/proxmox/wazuh/variables.tf
+++ b/proxmox/wazuh/variables.tf
@@ -1,0 +1,36 @@
+variable "pm_user" {
+  type = string
+}
+
+variable "pm_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "pm_api_url" {
+  type = string
+}
+
+variable "pm_node" {
+  type = string
+}
+
+variable "vm_defaults" {
+  description = "Default values for VM deployment"
+  sensitive = true
+  type = object({
+    username        = string
+    password        = string
+    storage_pool    = string
+    storage_size    = string
+    network_bridge  = string
+  })
+
+  default = {
+    username        = "ubuntu"
+    password        = "changeme"
+    storage_pool    = "truenas-iscsi"
+    storage_size    = "54784M"
+    network_bridge  = "vmbr0"
+  }
+}


### PR DESCRIPTION
## Summary
- New Wazuh SIEM VM on pve node: 16GB RAM, 4 cores, Ubuntu 24.04
- Static IP 192.168.1.171/24 via cloud-init
- State backend at /mnt/terraform-state/state/wazuh/
- Credentials stored in 1Password (Infrastructure vault, "Wazuh SIEM" item)

## Test plan
- [ ] `terraform plan` shows 1 resource to create
- [ ] `terraform apply` provisions VM successfully
- [ ] VM reachable at 192.168.1.171 via SSH
- [ ] Copy terraform.tfvars from another module (gitignored)