### PR TITLE
feat: add PostgreSQL VM and tags support to shared module

### DIFF
--- a/modules/proxmox/vm/main.tf
+++ b/modules/proxmox/vm/main.tf
@@ -24,6 +24,7 @@ resource "proxmox_vm_qemu" "this" {
   ciupgrade       = true
   sshkeys         = var.sshkeys
   ipconfig0       = each.value.ipconfig0
+  tags            = each.value.tags
   bootdisk        = "scsi0"
 
   disks {

--- a/modules/proxmox/vm/variables.tf
+++ b/modules/proxmox/vm/variables.tf
@@ -33,5 +33,6 @@ variable "vms" {
     full_clone      = bool
     hotplug         = string
     ipconfig0       = optional(string, "ip=dhcp")
+    tags            = optional(string, "")
   }))
 }

--- a/proxmox/postgresql/.gitignore
+++ b/proxmox/postgresql/.gitignore
@@ -1,0 +1,7 @@
+# Terraform secrets and state
+*.tfvars
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl
+crash.log

--- a/proxmox/postgresql/backend.tf
+++ b/proxmox/postgresql/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "local" {
+    path = "/mnt/terraform-state/state/postgresql/terraform.tfstate"
+  }
+}

--- a/proxmox/postgresql/locals.tf
+++ b/proxmox/postgresql/locals.tf
@@ -1,0 +1,22 @@
+locals {
+  sshkeys = file("~/.ssh/id_rsa.pub")
+  vms = {
+    postgresql = {
+      template        = "ubuntu-24-04-cloud-init-template"
+      username        = var.vm_defaults.username
+      password        = var.vm_defaults.password
+      memory          = 4096
+      cores           = 2
+      sockets         = 1
+      storage_pool    = var.vm_defaults.storage_pool
+      storage_size    = var.vm_defaults.storage_size
+      network_bridge  = var.vm_defaults.network_bridge
+      skip_ipv6       = true
+      onboot          = true
+      full_clone      = true
+      hotplug         = "network,disk,usb,memory,cpu"
+      ipconfig0       = "ip=192.168.1.123/24,gw=192.168.1.1"
+      tags            = "linux,databases"
+    }
+  }
+}

--- a/proxmox/postgresql/main.tf
+++ b/proxmox/postgresql/main.tf
@@ -1,0 +1,9 @@
+module "vms" {
+  source            = "../../modules/proxmox/vm"
+  proxmox_user      = var.pm_user
+  proxmox_password  = var.pm_password
+  proxmox_api_url   = var.pm_api_url
+  pm_node           = var.pm_node
+  vms               = local.vms
+  sshkeys           = local.sshkeys
+}

--- a/proxmox/postgresql/outputs.tf
+++ b/proxmox/postgresql/outputs.tf
@@ -1,0 +1,7 @@
+output "vm_ids" {
+  value = module.vms.vm_ids
+}
+
+output "vm_ips" {
+  value = module.vms.vm_ips
+}

--- a/proxmox/postgresql/variables.tf
+++ b/proxmox/postgresql/variables.tf
@@ -1,0 +1,36 @@
+variable "pm_user" {
+  type = string
+}
+
+variable "pm_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "pm_api_url" {
+  type = string
+}
+
+variable "pm_node" {
+  type = string
+}
+
+variable "vm_defaults" {
+  description = "Default values for VM deployment"
+  sensitive = true
+  type = object({
+    username        = string
+    password        = string
+    storage_pool    = string
+    storage_size    = string
+    network_bridge  = string
+  })
+
+  default = {
+    username        = "ubuntu"
+    password        = "changeme"
+    storage_pool    = "truenas-iscsi"
+    storage_size    = "54784M"
+    network_bridge  = "vmbr0"
+  }
+}


### PR DESCRIPTION
- Add tags attribute to shared Proxmox VM module (optional, default empty)
- Create PostgreSQL VM (192.168.1.123) on pve2 with linux,databases tags
- 2 vCPU, 4GB RAM, ~53GB disk for shared database server
- Initial use: Grafana backend (replacing SQLite), future services