### PR TITLE
fix: default cloud-init user to ladino instead of ubuntu

### DIFF
--- a/proxmox/postgresql/variables.tf
+++ b/proxmox/postgresql/variables.tf
@@ -27,7 +27,7 @@ variable "vm_defaults" {
   })
 
   default = {
-    username        = "ubuntu"
+    username        = "ladino"
     password        = "changeme"
     storage_pool    = "truenas-iscsi"
     storage_size    = "54784M"


### PR DESCRIPTION
All VMs should use ladino as the ciuser to match Ansible inventory expectations. Previously defaulted to ubuntu which required manual user creation before Ansible could connect.