### PR TITLE
jellyfin: bump cores 6 → 12 for CPU transcoding

### DIFF
--- a/proxmox/jellyfin/locals.tf
+++ b/proxmox/jellyfin/locals.tf
@@ -6,7 +6,7 @@ locals {
       username        = var.vm_defaults.username
       password        = var.vm_defaults.password
       memory          = 12288
-      cores           = 6
+      cores           = 12
       sockets         = 1
       storage_pool    = var.vm_defaults.storage_pool
       storage_size    = var.vm_defaults.storage_size


### PR DESCRIPTION
Follow-up to the Jellyfin GPU→CPU transcoding move (ansible-quasarlab#134).

GPU passthrough was removed from VM 115; transcoding now runs in software on the Ryzen 9 5950X. Bumps `cores` 6 → 12 so the VM can comfortably handle 1-2 concurrent 4K software transcodes (host is 16C/32T). This matches the live VM config and prevents terraform from reverting cores to 6 on the next apply.