### PR TITLE
chore: gitignore tfplan artifacts and local .mcp.json

### DIFF
--- a/proxmox/jellyfin/.gitignore
+++ b/proxmox/jellyfin/.gitignore
@@ -6,5 +6,3 @@
 .terraform.lock.hcl
 crash.log
 
-.mcp.json
-tfplan


### PR DESCRIPTION
Ignore Terraform `tfplan` plan files (binary plan archives can embed resolved sensitive values, should never be committed) and the local-only `.mcp.json`. Adds a module-level `.gitignore` under proxmox/jellyfin for tfstate/tfvars.